### PR TITLE
Fix typo in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -107,7 +107,7 @@ coverage/
 test_*.pdf
 *_secrets.pdf
 AKIAIOSFODNN7EXAMPLE.pdf
-file_with_secrest.pdf
+file_with_secrets.pdf
 
 .cursorignore
 Style.css


### PR DESCRIPTION
## Summary
- fix the filename typo in `.gitignore`

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68545a4fb370832299b4610eb7aacb5d