### PR TITLE
Implement in-memory debug logging

### DIFF
--- a/inspection-service/utils/logger.js
+++ b/inspection-service/utils/logger.js
@@ -124,6 +124,17 @@ class Logger {
       this.info(message, { secretsFound: false });
     }
   }
+
+  /**
+   * Log structured PDF debug information
+   * @param {object} data - Debug metadata
+   */
+  debugPDF(data) {
+    if (this.level >= LOG_LEVELS.debug) {
+      console.log(this.formatMessage('debug', 'PDF Debug Entry'));
+      console.table(data);
+    }
+  }
 }
 
 // Create default logger instance


### PR DESCRIPTION
## Summary
- support structured PDF debug logging in logger
- add in-memory debug cache and stats
- expose debug API endpoints when in development mode
- log debug endpoints on startup

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68545de478988322bc0c72c3f2a4baba